### PR TITLE
Fix start server processe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Uncomment these lines to include your own data in the repository:
-
+venv
 data/*.gpkg
 data/*.csv
 datapackage.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # Uncomment these lines to include your own data in the repository:
 venv
-data/*.gpkg
-data/*.csv
-datapackage.json
+
 
 # Uncomment this to allow Pipenv to manage your Python environment:
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,2 +1,2 @@
 falcon
-pandas-datapackage-reader
+frictionless==4.40.8

--- a/api/server.py
+++ b/api/server.py
@@ -1,10 +1,10 @@
 import falcon
+from frictionless import Package
 from wsgiref.simple_server import make_server
-from pandas_datapackage_reader import read_datapackage
 
 api = falcon.API()
 
-data = read_datapackage("..")
+package = Package('datapackage.json')
 
 def get_paginated_json(req, df):
     per_page = int(req.get_param('per_page', required=False, default=10))
@@ -17,8 +17,8 @@ class DataResource:
         self.resource = data
 
     def on_get(self, req, resp):
-        df = self.resource.copy()
-        for fld in self.resource._metadata['schema']['fields']:
+        df = self.resource.to_pandas().copy()
+        for fld in self.resource.schema['fields']:
             fn = fld['name']
             q = req.get_param(fn, None)
             if q is not None:
@@ -32,8 +32,8 @@ class DataResource:
         resp.status = falcon.HTTP_200
         resp.body = get_paginated_json(req, df)
 
-for resource in data['resources']:
-    api.add_route("/%s" % resource['name'], DataResource(resource))
+for resource in package.resources:
+    api.add_route("/%s" % resource.name, DataResource(resource))
 
 if __name__ == '__main__':
     with make_server('', 8000, api) as httpd:

--- a/data/users.csv
+++ b/data/users.csv
@@ -1,0 +1,5 @@
+id,name,age
+1,John,30
+2,Paul,25
+3,Ringo,36
+4,George,50

--- a/datapackage.json
+++ b/datapackage.json
@@ -1,0 +1,42 @@
+{
+  "resources": [
+    {
+      "path": "data/users.csv",
+      "name": "users",
+      "title": "Usuários",
+      "description": "Lista de usuários cadastrados para recebimento de doações",
+      "profile": "tabular-data-resource",
+      "scheme": "file",
+      "format": "csv",
+      "hashing": "md5",
+      "encoding": "utf-8",
+      "schema": {
+        "fields": [
+          {
+            "type": "integer",
+            "name": "id"
+          },
+          {
+            "type": "string",
+            "name": "name",
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "type": "integer",
+            "name": "age",
+            "constraints": {
+              "required": true
+            }
+          }
+        ],
+        "primaryKey": "id"
+      },
+      "dialect": {
+        "delimiter": ","
+      }
+    }
+  ],
+  "profile": "data-package"
+}


### PR DESCRIPTION
Hello @loleg and @n0rdlicht!

Gabriel here from Brazil. I watched the [Frictionless Data last Community Call of the year 2022](https://frictionlessdata.io/blog/2023/01/06/datapackage-as-a-service/) when you presented this project I thought it was an excellent idea. Congratulations in advance.

[I cloned it](https://github.com/gabrielbdornas/pacoa-api) and tried to use it but with some errors. So I think it could be a good idea to show some solutions throughout this PR.

Well, the changes proposed here are basically:

- Use the `frictionless` framework inside the `api/server.py`. Honestly, I didn't know so much `pandas_datapackage_reader` library and the error presented was exactly in it. As the `frictionless` framework was able to fix the problem and could be used in the future in other functionalities I imagined it could be a worthwhile change.
- Add the `venv` folder to `.gitignore`, to improve project readability (just a suggestion!!).
- Remove the `datapackage.json` and the `data` folder to `.gitignore`. I thought presenting first users with an example could help them better understand the project.

Furthermore, I have other ideas to help improve this repository like:

- Implement the folly CRUD process.
- Implement basic login implementation.
- Give users more complex dataset examples.
- Improve documentation during project growth.
- Write some tutorials to show users how to use free platforms, like [Python Everywhere](https://www.pythonanywhere.com/) to host their tyne APIs for free, or almost if possible.

Let me know if you are interested in it. It'll be a pleasure to help with it!